### PR TITLE
feat: Improve frontend handling of real restaurant data

### DIFF
--- a/apps/frontend/hooks/useRestaurantData.ts
+++ b/apps/frontend/hooks/useRestaurantData.ts
@@ -4,6 +4,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { apiClient, Restaurant, RestaurantMenu, MarketAnalysis, MenuItem } from '../lib/api-client';
+import { FEATURES } from '../lib/config';
 
 export interface UseRestaurantsResult {
   restaurants: Restaurant[];
@@ -401,8 +402,12 @@ export function useLocationBasedRestaurants() {
           last_search: new Date().toISOString()
         });
       } else {
-        console.warn('⚠️ No restaurants found, using demo data');
-        setRestaurants(getDemoRestaurants(lat, lng));
+        if (FEATURES.ENABLE_REAL_DATA) {
+          setRestaurants(response.data || []);
+        } else {
+          console.warn('⚠️ No restaurants found, using demo data');
+          setRestaurants(getDemoRestaurants(lat, lng));
+        }
       }
     } catch (err) {
       console.error('❌ Error fetching restaurants:', err);
@@ -513,7 +518,11 @@ export function useLocationBasedRestaurants() {
             last_search: new Date().toISOString()
           });
         } else {
-          setRestaurants(getDemoRestaurants(lat, lng));
+          if (FEATURES.ENABLE_REAL_DATA) {
+            setRestaurants(fallbackResponse.data || []);
+          } else {
+            setRestaurants(getDemoRestaurants(lat, lng));
+          }
         }
       } catch (fallbackErr) {
         console.error('Fallback search also failed:', fallbackErr);
@@ -566,7 +575,11 @@ export function useLocationBasedRestaurants() {
             last_search: new Date().toISOString()
           });
         } else {
-          setRestaurants(getDemoRestaurants(lat, lng));
+          if (FEATURES.ENABLE_REAL_DATA) {
+            setRestaurants(fallbackResponse.data || []);
+          } else {
+            setRestaurants(getDemoRestaurants(lat, lng));
+          }
         }
       } catch (fallbackErr) {
         console.error('Fallback search also failed:', fallbackErr);


### PR DESCRIPTION
Modifies the `useLocationBasedRestaurants` hook in `apps/frontend/hooks/useRestaurantData.ts` to more accurately handle responses when real data is enabled via the `FEATURES.ENABLE_REAL_DATA` flag.

When this flag is true and an API call for restaurant data is successful but returns an empty list (indicating no results from the real external source), the frontend will now display an empty list rather than falling back to demo data.

Demo data is now primarily used if `FEATURES.ENABLE_REAL_DATA` is false, or if an actual error occurs during the API request.

This change is preparatory for backend updates that will integrate real external data sources (e.g., Foursquare, Google Places).