### PR TITLE
fix: Prioritize real data for location-based restaurants

### DIFF
--- a/apps/frontend/hooks/useRestaurantData.ts
+++ b/apps/frontend/hooks/useRestaurantData.ts
@@ -402,18 +402,25 @@ export function useLocationBasedRestaurants() {
           last_search: new Date().toISOString()
         });
       } else {
+        // If API returns no data (empty array or null)
         if (FEATURES.ENABLE_REAL_DATA) {
-          setRestaurants(response.data || []);
+          setRestaurants(response.data || []); // Set to empty array if null/undefined
+          if (response.error) setError(response.error); // Preserve error from response if any
         } else {
-          console.warn('⚠️ No restaurants found, using demo data');
+          console.warn('⚠️ No restaurants found and real data disabled, using demo data');
           setRestaurants(getDemoRestaurants(lat, lng));
         }
       }
     } catch (err) {
       console.error('❌ Error fetching restaurants:', err);
-      setError('Failed to fetch nearby restaurants');
-      // Load demo data as fallback
-      setRestaurants(getDemoRestaurants(lat, lng));
+      const errorMsg = err instanceof Error ? err.message : 'Failed to fetch nearby restaurants';
+      setError(errorMsg);
+      if (FEATURES.ENABLE_REAL_DATA) {
+        setRestaurants([]); // Set to empty array on error if real data is enabled
+      } else {
+        console.warn('⚠️ Error fetching restaurants and real data disabled, using demo data');
+        setRestaurants(getDemoRestaurants(lat, lng));
+      }
     } finally {
       setLoading(false);
     }
@@ -526,8 +533,14 @@ export function useLocationBasedRestaurants() {
         }
       } catch (fallbackErr) {
         console.error('Fallback search also failed:', fallbackErr);
-        setError('Failed to fetch nearby restaurants');
-        setRestaurants(getDemoRestaurants(lat, lng));
+        const errorMsg = fallbackErr instanceof Error ? fallbackErr.message : 'Failed to fetch nearby restaurants';
+        setError(errorMsg);
+        if (FEATURES.ENABLE_REAL_DATA) {
+          setRestaurants([]);
+        } else {
+          console.warn('⚠️ Fallback search failed and real data disabled, using demo data');
+          setRestaurants(getDemoRestaurants(lat, lng));
+        }
       }
     } finally {
       setLoading(false);
@@ -583,8 +596,14 @@ export function useLocationBasedRestaurants() {
         }
       } catch (fallbackErr) {
         console.error('Fallback search also failed:', fallbackErr);
-        setError('Failed to fetch nearby restaurants');
-        setRestaurants(getDemoRestaurants(lat, lng));
+        const errorMsg = fallbackErr instanceof Error ? fallbackErr.message : 'Failed to fetch nearby restaurants';
+        setError(errorMsg);
+        if (FEATURES.ENABLE_REAL_DATA) {
+          setRestaurants([]);
+        } else {
+          console.warn('⚠️ Fallback search failed (buffer) and real data disabled, using demo data');
+          setRestaurants(getDemoRestaurants(lat, lng));
+        }
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
Modified the `useLocationBasedRestaurants` hook to ensure that when `FEATURES.ENABLE_REAL_DATA` is true:
- API errors during location-based restaurant searches will result in an error state and an empty list of restaurants, rather than falling back to mock data.
- Successful API calls that return no data will also result in an empty list of restaurants.

This change provides more transparent error handling and ensures that mock data is only used when real data is explicitly disabled or as a last resort in those specific cases, not when real data fetching fails.